### PR TITLE
Add Reset All Times button to schedule header

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -767,3 +767,20 @@ body {
     display: none !important;
 }
 
+
+
+/* Reset All Button */
+.btn-reset-all {
+    background: #dc3545;
+    color: white;
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    margin-right: 1rem;
+}
+
+.btn-reset-all:hover {
+    background: #c82333;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,7 +43,12 @@
             {% if sheet_tab %}
             <span class="sheet-tab-label">Sheet: {{ sheet_tab }}</span>
             {% endif %}
-            <button class="btn-toggle-completed" @click="hideCompleted = !hideCompleted">
+	    {% if not view_only %}
+            <button class="btn-reset-all" @click="confirmMessage = 'Reset all actual times? This will clear all recorded start and end times.'; confirmUrl = '/api/reset'">
+                Reset All Times
+            </button>
+            {% endif %}
+	    <button class="btn-toggle-completed" @click="hideCompleted = !hideCompleted">
                 <span x-text="hideCompleted ? 'Show Completed' : 'Hide Completed'"></span>
             </button>
         </div>


### PR DESCRIPTION
# Add Reset All Times Button

## Description
Adds a "Reset All Times" button to the schedule header in edit mode that allows clearing all actual start/end times at once.

## Changes
- Added red warning-styled button that appears only in edit mode
- Button triggers the existing confirmation modal before executing reset
- Positioned in schedule header before "Hide Completed" button
- Added `.btn-reset-all` CSS styling with hover state

## Dependencies
- Requires the `/api/reset` endpoint (already merged in #2)
- Uses existing confirmation modal infrastructure

## Testing
- [x] Button appears in edit mode only
- [x] Button hidden in view-only mode
- [x] Confirmation modal displays correct warning message
- [x] Successfully calls `/api/reset` endpoint after confirmation
- [x] Visual styling matches warning/danger intent (red button)

## Screenshots
Button appears in edit mode with proper styling and positioning in the schedule header.

## Notes
This PR is a clean extraction of just the UI button component. The backend `/api/reset` endpoint was already merged in PR #2.